### PR TITLE
Fix the list of configuration constants in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,12 +69,10 @@ Once you're inside tmux-url-select, keybindings:
 There's a bunch of constants near the top of the file, you can modify them to
 your liking.
 
-    use constant COMMAND => 'xdg-open %s';
-    use constant YANK_COMMAND => 'echo %s | xclip -i';
-
     use constant SHOW_STATUS_BAR => 1;
     use constant VERBOSE_MESSAGES => 0;
     use constant TMUX_WINDOW_TITLE => 'Select URL';
+    use constant TMUX_WINDOW_ID => 9999;
 
     use constant PROMPT_COLOR => "\033[42;30m";
     use constant ACTIVE_LINK_HIGHLIGHT => "\033[44;4m";


### PR DESCRIPTION
Fixed the list of available configuration constants that show in the README to match those in the script:

- COMMAND and YANK_COMMAND are removed since they are obsolete with the introduction of the corresponding environment variables.
- Added the constant TMUX_WINDOW_ID
- Did not add HIDE_WINDOW since it appears to be unused: #10